### PR TITLE
README.md "Example usage" port fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Default CMD is `webfsd -p 80 -d -r /srv`.
 Example usage:
 
 ```
-docker run -it -p80 -v /your/webroot:/srv jonashaag/webfsd
+docker run -it -p80:80 -v /your/webroot:/srv jonashaag/webfsd
 ```


### PR DESCRIPTION
`-p` argument takes `*:*` value, instead of `*`, so now example works without tweaking